### PR TITLE
chore: relax lint rules for unescaped entities

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "react/no-unescaped-entities": "off",
+    "@next/next/no-assign-module-variable": "off"
+  }
 }


### PR DESCRIPTION
## Summary
- disable `react/no-unescaped-entities`
- turn off `@next/next/no-assign-module-variable`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fd6b64a00833283bcc82f2f338301